### PR TITLE
[GBI-1094] -  increase unit tests for pwd complexity check

### DIFF
--- a/providers/liquidity.go
+++ b/providers/liquidity.go
@@ -256,10 +256,10 @@ func createPasswd(in *os.File) (string, error) {
 		return "", err
 	}
 
-	const minEntropyBits = 70
+	const minEntropyBits = 100
 	err = passwordvalidator.Validate(pwd1, minEntropyBits)
 	if err != nil {
-		return "", errors.New("password is not secure enough")
+		return "", errors.New("password is not secure enough: " + err.Error())
 	}
 
 	fmt.Print("repeat password: ")


### PR DESCRIPTION
https://rsklabs.atlassian.net/browse/GBI-1094?atlOrigin=eyJpIjoiYWZlMGU0ODhhN2Q2NGQ4YWJjNDMzNjc2ZTlkZjAzNzkiLCJwIjoiaiJ9
increse unit test coverage with pwd complexity check rules:

for a pwd to be secure enough, it uses a complex math function to verify it's entropy: 
`calculate log2(base^length)` where base is calculated accordingly to how much special chars, numbers, and upper/lower cases the string has
and length is the size of the string removing sequences, common replacements and repeated chars.

Usually to have an entropy higher than 100 (what we require) you can bypass it with:
- string size 16
- numbers
- upper and lower cases
- separation special chars `_-., `
- replacement special chars `!@$&*`
- others special chars `"#%'()+/:;<=>?[\]^{|}~`

but for example, having a password with more than 20chars and at least any 3 special chars between words, is enough.
example: `correct horse battery staple`

ref: github.com/wagslane/go-password-validator